### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit APDS9960 gesture/proximity/color/light sensor.
 paragraph=This is a library for the Adafruit APDS9960 gesture/proximity/color/light sensor.
-category=Sensor
+category=Sensors
 url=https://github.com/adafruit/Adafruit_APDS9960
 architectures=*


### PR DESCRIPTION
The previous `category` value causes a warning on every compilation:
```
WARNING: Category 'Sensor' in library Adafruit APDS9960 Library is not valid. Setting to 'Uncategorized'
```
Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format