### PR TITLE
Add Raspberry PI support to Adafruit_APDS9960

### DIFF
--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -36,10 +36,35 @@
 #ifndef _APDS9960_H_
 #define _APDS9960_H_
 
+#ifndef RASPBERRY_PI
+
 #include <Arduino.h>
 #include <Wire.h>
 
 #define I2CDEBUG
+
+#else // ifndef RASPBERRY_PI
+
+#include <wiringPi.h>
+#include <wiringPiI2C.h>
+
+#ifndef boolean
+typedef bool boolean;
+#endif
+#ifndef byte
+typedef char byte;
+#endif
+#ifndef uint8_t
+typedef unsigned char uint8_t;
+#endif
+#ifndef uint16_t
+typedef unsigned short uint16_t;
+#endif
+#ifndef uint32_t
+typedef unsigned int uint32_t;
+#endif
+
+#endif // ifndef RASPBERRY_PI
 
 /*=========================================================================
     I2C ADDRESS/BITS
@@ -553,6 +578,9 @@ class Adafruit_APDS9960 {
 	};
 	gstatus _gstatus;
   
+#ifdef RASPBERRY_PI
+	int _i2cfd;
+#endif // ifdef RASPBERRY_PI
 };
 
 #endif

--- a/examples/color_sensor/color_sensor.ino
+++ b/examples/color_sensor/color_sensor.ino
@@ -19,13 +19,28 @@
 #include "Adafruit_APDS9960.h"
 Adafruit_APDS9960 apds;
 
+#ifdef RASPBERRY_PI
+#include <stdio.h>
+#include <stdlib.h>
+#endif // ifdef RASPBERRY_PI
+
 void setup() {
+#ifndef RASPBERRY_PI
   Serial.begin(115200);
 
   if(!apds.begin()){
     Serial.println("failed to initialize device! Please check your wiring.");
   }
   else Serial.println("Device initialized!");
+#else // ifndef RASPBERRY_PI
+  wiringPiSetup();
+
+  if(!apds.begin()){
+    puts("failed to initialize device! Please check your wiring.\n");
+    abort();
+  }
+  else puts("Device initialized!");
+#endif // ifndef RASPBERRY_PI
 
   //enable color sensign mode
   apds.enableColor(true);
@@ -42,6 +57,8 @@ void loop() {
 
   //get the data and print the different channels
   apds.getColorData(&r, &g, &b, &c);
+
+#ifndef RASPBERRY_PI
   Serial.print("red: ");
   Serial.print(r);
   
@@ -54,6 +71,16 @@ void loop() {
   Serial.print(" clear: ");
   Serial.println(c);
   Serial.println();
-  
+#else // ifndef RASPBERRY_PI
+  printf("red: %d green: %d blue: %d clear: %d\n", r, g, b, c);
+#endif // ifndef RASPBERRY_PI
+
   delay(500);
 }
+
+#ifdef RASPBERRY_PI
+int main(int argc, char* argv[]) {
+  setup();
+  while (true) loop();
+}
+#endif // ifdef RASPBERRY_PI

--- a/examples/gesture_sensor/gesture_sensor.ino
+++ b/examples/gesture_sensor/gesture_sensor.ino
@@ -22,14 +22,29 @@
 #include "Adafruit_APDS9960.h"
 Adafruit_APDS9960 apds;
 
+#ifdef RASPBERRY_PI
+#include <stdio.h>
+#include <stdlib.h>
+#endif // ifdef RASPBERRY_PI
+
 // the setup function runs once when you press reset or power the board
 void setup() {
+#ifndef RASPBERRY_PI
   Serial.begin(115200);
   
   if(!apds.begin()){
     Serial.println("failed to initialize device! Please check your wiring.");
   }
   else Serial.println("Device initialized!");
+#else // ifndef RASPBERRY_PI
+  wiringPiSetup();
+
+  if(!apds.begin()){
+    puts("failed to initialize device! Please check your wiring.\n");
+    abort();
+  }
+  else puts("Device initialized!");
+#endif // ifndef RASPBERRY_PI
 
   //gesture mode will be entered once proximity mode senses something close
   apds.enableProximity(true);
@@ -40,8 +55,22 @@ void setup() {
 void loop() {
   //read a gesture from the device
     uint8_t gesture = apds.readGesture();
+#ifndef RASPBERRY_PI
     if(gesture == APDS9960_DOWN) Serial.println("v");
     if(gesture == APDS9960_UP) Serial.println("^");
     if(gesture == APDS9960_LEFT) Serial.println("<");
     if(gesture == APDS9960_RIGHT) Serial.println(">");
+#else // ifndef RASPBERRY_PI
+    if(gesture == APDS9960_DOWN) puts("v");
+    if(gesture == APDS9960_UP) puts("^");
+    if(gesture == APDS9960_LEFT) puts("<");
+    if(gesture == APDS9960_RIGHT) puts(">");
+#endif // ifndef RASPBERRY_PI
 }
+
+#ifdef RASPBERRY_PI
+int main(int argc, char* argv[]) {
+  setup();
+  while (true) loop();
+}
+#endif // ifdef RASPBERRY_PI


### PR DESCRIPTION
This is a non-intrusive way of using this library on RPI.
It runs faster than python, but possibly not as portable.

Here are the steps for building and linking a c++ program
with it:

```
echo do these once, so your program is able to use wiringPi
sudo apt-get update
sudo apt-get install -y git build-essential g++
git clone git://git.drogon.net/wiringPi && cd wiringPi && ./build

cd ~/Adafruit_APDS9960.git ; # wherever this repo is located!
g++ -DRASPBERRY_PI -c Adafruit_APDS9960.cpp

cd examples/gesture_sensor
g++ -DRASPBERRY_PI -x c++ -o gesture_sensor.o -c gesture_sensor.ino -I ../..
g++ -DRASPBERRY_PI -o gesture_sensor  gesture_sensor.o  ../../Adafruit_APDS9960.o -lwiringPi
sudo ./gesture_sensor

cd ../../examples/proximity_sensor/
g++ -DRASPBERRY_PI -x c++ -o proximity_sensor.o -c proximity_sensor.ino -I ../..
g++ -DRASPBERRY_PI -o proximity_sensor  proximity_sensor.o  ../../Adafruit_APDS9960.o -lwiringPi
sudo ./proximity_sensor

cd ../../examples/color_sensor/
g++ -DRASPBERRY_PI -x c++ -o color_sensor.o -c color_sensor.ino -I ../..
g++ -DRASPBERRY_PI -o color_sensor  color_sensor.o  ../../Adafruit_APDS9960.o -lwiringPi
sudo ./color_sensor
```