### PR TITLE
Fix warning unused variable in readGesture and bit shifting in read32

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -391,7 +391,7 @@ void Adafruit_APDS9960::resetCounts() {
  *          APDS9960_RIGHT)
  */
 uint8_t Adafruit_APDS9960::readGesture() {
-  uint8_t toRead, bytesRead;
+  uint8_t toRead;
   uint8_t buf[256];
   unsigned long t = 0;
   uint8_t gestureReceived;
@@ -405,9 +405,8 @@ uint8_t Adafruit_APDS9960::readGesture() {
     delay(30);
     toRead = this->read8(APDS9960_GFLVL);
 
-    // bytesRead is unused but produces sideffects needed for readGesture to
-    // work
-    bytesRead = this->read(APDS9960_GFIFO_U, buf, toRead);
+    // produces sideffects needed for readGesture to work
+    this->read(APDS9960_GFIFO_U, buf, toRead);
 
     if (abs((int)buf[0] - (int)buf[1]) > 13)
       up_down_diff += (int)buf[0] - (int)buf[1];
@@ -638,9 +637,13 @@ uint8_t Adafruit_APDS9960::read8(byte reg) {
  */
 uint32_t Adafruit_APDS9960::read32(uint8_t reg) {
   uint8_t ret[4];
+  uint32_t ret32;
   this->read(reg, ret, 4);
-
-  return (ret[0] << 24) | (ret[1] << 16) | (ret[2] << 8) | ret[3];
+  ret32 = ret[3];
+  ret32 |= (uint32_t)ret[2] << 8;
+  ret32 |= (uint32_t)ret[1] << 16;
+  ret32 |= (uint32_t)ret[0] << 24;
+  return ret32;
 }
 
 /*!


### PR DESCRIPTION
- Arduino board:  **Original board with 328PB**
- Arduino IDE version (found in Arduino -> About Arduino menu):  **1.8.12**
- List the steps to reproduce the problem below (if possible attach a sketch or
  copy the sketch code in too): **build my sample ino**

I got the following warnings.
```
/Users/takashi/Documents/Arduino/libraries/Adafruit_APDS9960-1.1.3/Adafruit_APDS9960.cpp: In member function 'uint8_t Adafruit_APDS9960::readGesture()':
/Users/takashi/Documents/Arduino/libraries/Adafruit_APDS9960-1.1.3/Adafruit_APDS9960.cpp:394:19: warning: variable 'bytesRead' set but not used [-Wunused-but-set-variable]
   uint8_t toRead, bytesRead;
                   ^~~~~~~~~
/Users/takashi/Documents/Arduino/libraries/Adafruit_APDS9960-1.1.3/Adafruit_APDS9960.cpp: In member function 'uint32_t Adafruit_APDS9960::read32(uint8_t)':
/Users/takashi/Documents/Arduino/libraries/Adafruit_APDS9960-1.1.3/Adafruit_APDS9960.cpp:643:21: warning: left shift count >= width of type [-Wshift-count-overflow]
   return (ret[0] << 24) | (ret[1] << 16) | (ret[2] << 8) | ret[3];
                     ^~
/Users/takashi/Documents/Arduino/libraries/Adafruit_APDS9960-1.1.3/Adafruit_APDS9960.cpp:643:38: warning: left shift count >= width of type [-Wshift-count-overflow]
   return (ret[0] << 24) | (ret[1] << 16) | (ret[2] << 8) | ret[3];
                                      ^~
```

There is comment of `bytesRead is unused but produces sideffects needed for readGesture to work` but it seems OK with only reading `APDS9960_GFIFO_U` register and `bytesRead` variable itself can be removed.

And I cast `uint32_t` before bit shifting.