### PR TITLE
Update Adafruit_APDS9960.cpp

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -201,7 +201,7 @@ void Adafruit_APDS9960::setProxGain(apds9960PGain_t pGain) {
  *  @return Proxmity gain
  */
 apds9960PGain_t Adafruit_APDS9960::getProxGain() {
-  return (apds9960PGain_t)(read8(APDS9960_CONTROL) & 0x0C);
+  return (apds9960PGain_t)((read8(APDS9960_CONTROL) & 0x0C)>>2);
 }
 
 /*!

--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -201,7 +201,7 @@ void Adafruit_APDS9960::setProxGain(apds9960PGain_t pGain) {
  *  @return Proxmity gain
  */
 apds9960PGain_t Adafruit_APDS9960::getProxGain() {
-  return (apds9960PGain_t)((read8(APDS9960_CONTROL) & 0x0C)>>2);
+  return (apds9960PGain_t)((read8(APDS9960_CONTROL) & 0x0C) >> 2);
 }
 
 /*!


### PR DESCRIPTION
Fixed getProxGain method so it returns the content of the bitfield PGAIN as in the datasheet.
Now calling the method getProxGain will return 0, 1, 2 or 3 as in the APDS9960 datasheet.
Was tested together with the proximity example.
