### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -31,8 +31,8 @@
 #ifndef _APDS9960_H_
 #define _APDS9960_H_
 
+#include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
-#include <Wire.h>
 
 #define APDS9960_ADDRESS (0x39) /**< I2C Address */
 
@@ -222,8 +222,7 @@ public:
   void enable(boolean en = true);
 
 private:
-  uint8_t _i2caddr;
-  TwoWire *_wire;
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
 
   uint32_t read32(uint8_t reg);
   uint16_t read16(uint8_t reg);
@@ -242,7 +241,6 @@ private:
 
   uint8_t read(uint8_t reg, uint8_t *buf, uint8_t num);
   void write(uint8_t reg, uint8_t *buf, uint8_t num);
-  void _i2c_init();
 
   struct enable {
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit APDS9960 Library
-version=1.1.5
+version=1.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit APDS9960 gesture/proximity/color/light sensor.

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This is a library for the Adafruit APDS9960 gesture/proximity/color/li
 category=Sensors
 url=https://github.com/adafruit/Adafruit_APDS9960
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #31. Converts to using BusIO with not additional changes to existing library API.

Tested with Qt PY and examples from library. Here's `color_sensor`:
![Screenshot from 2021-08-09 15-53-34](https://user-images.githubusercontent.com/8755041/128784424-33ba98f6-9653-4a49-887c-1ec0e86a84c8.png)
