### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -59,6 +59,11 @@ float powf(const float x, const float y) {
   return (float)(pow((double)x, (double)y));
 }
 
+Adafruit_APDS9960::~Adafruit_APDS9960() {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
 /*!
  *  @brief  Enables the device
  *          Disables the device (putting it in lower power sleep mode)
@@ -85,6 +90,8 @@ void Adafruit_APDS9960::enable(boolean en) {
 boolean Adafruit_APDS9960::begin(uint16_t iTimeMS, apds9960AGain_t aGain,
                                  uint8_t addr, TwoWire *theWire) {
 
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(addr, theWire);
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -173,7 +173,7 @@ enum {
 class Adafruit_APDS9960 {
 public:
   Adafruit_APDS9960(){};
-  ~Adafruit_APDS9960(){};
+  ~Adafruit_APDS9960();
 
   boolean begin(uint16_t iTimeMS = 10, apds9960AGain_t = APDS9960_AGAIN_4X,
                 uint8_t addr = APDS9960_ADDRESS, TwoWire *theWire = &Wire);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit APDS9960 Library
-version=1.2.0
+version=1.2.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit APDS9960 gesture/proximity/color/light sensor.


### PR DESCRIPTION
Tested on Qt PY:
```cpp
#include "Adafruit_APDS9960.h"

Adafruit_APDS9960 apds;

void setup() {
  Serial.begin(9600);
  while(!Serial);

  Serial.println("APDS9960 multi begin() test.");
}

void loop() {
  if(!apds.begin()){
    Serial.println("Failed to initialize device! Please check your wiring.");
  }

  apds.enableProximity(true);

  delay(500);
  
  Serial.println(apds.readProximity());

  delay(500);
}
```

![Screenshot from 2021-08-24 16-44-00](https://user-images.githubusercontent.com/8755041/130704088-d9e26850-6c01-4755-961e-9516cb3837c7.png)
