### PR TITLE
AJH typo fixes

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -267,23 +267,23 @@ void Adafruit_APDS9960::disableProximityInterrupt() {
  *          Low threshold
  *  @param  high
  *          High threshold
- *  @param  persistance
- *          Persistance
+ *  @param  persistence
+ *          Persistence
  */
 void Adafruit_APDS9960::setProximityInterruptThreshold(uint8_t low,
                                                        uint8_t high,
-                                                       uint8_t persistance) {
+                                                       uint8_t persistence) {
   write8(APDS9960_PILT, low);
   write8(APDS9960_PIHT, high);
 
-  if (persistance > 7)
-    persistance = 7;
+  if (persistence > 7)
+    persistence = 7;
   _pers.PPERS = persistance;
   write8(APDS9960_PERS, _pers.get());
 }
 
 /*!
- *  @brief  Returns proxmity interrupt status
+ *  @brief  Returns proximity interrupt status
  *  @return True if enabled, false otherwise.
  */
 bool Adafruit_APDS9960::getProximityInterrupt() {
@@ -309,8 +309,8 @@ bool Adafruit_APDS9960::gestureValid() {
 /*!
  *  @brief  Sets gesture dimensions
  *  @param  dims
- *          Dimensions (APDS9960_DIMENSIONS_ALL, APDS9960_DIMENSIONS_UP_DOWM,
- *          APDS9960_DIMENSIONS_UP_DOWN, APGS9960_DIMENSIONS_LEFT_RIGHT)
+ *          Dimensions (APDS9960_DIMENSIONS_ALL, APDS9960_DIMENSIONS_UP_DOWN,
+ *          APGS9960_DIMENSIONS_LEFT_RIGHT)
  */
 void Adafruit_APDS9960::setGestureDimensions(uint8_t dims) {
   _gconf3.GDIMS = dims;

--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -278,7 +278,7 @@ void Adafruit_APDS9960::setProximityInterruptThreshold(uint8_t low,
 
   if (persistence > 7)
     persistence = 7;
-  _pers.PPERS = persistance;
+  _pers.PPERS = persistence;
   write8(APDS9960_PERS, _pers.get());
 }
 

--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -192,7 +192,7 @@ public:
   void disableProximityInterrupt();
   uint8_t readProximity();
   void setProximityInterruptThreshold(uint8_t low, uint8_t high,
-                                      uint8_t persistance = 4);
+                                      uint8_t persistence = 4);
   bool getProximityInterrupt();
 
   // gesture


### PR DESCRIPTION
- Describe the scope of your change:
    Renamed persistance to persistence in Adafruit_APDS9960.cpp lines 270, 271, 275, and 279.
    Renamed proxmity to proximity in Adafruit_APDS9960.cpp line 286.
    Removed APDS9960_DIMENSIONS_UP_DOWM from a comment in Adafruit_APDS9960.cpp line 312, and reformatted the remainder of the comment.
    Renamed persistance to persistence in Adafruit_APDS9960.h line 195.

- Describe any known limitations with your change - No known limitations.

- Please run any tests or examples that can exercise your modified code - This branch performs the same on an ESP32S3 (Lilygo T-Display-S3)