### PR TITLE
[FEATURE] Make clones of APDS9960 work too with this library

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -98,8 +98,8 @@ boolean Adafruit_APDS9960::begin(uint16_t iTimeMS, apds9960AGain_t aGain,
   }
 
   /* Make sure we're actually connected */
-  uint8_t x = read8(APDS9960_ID);
-  if (x != 0xAB) {
+  uint8_t id = read8(APDS9960_ID);
+  if (!(id != APDS9960_DEVICE_ID_1 || id != APDS9960_DEVICE_ID_2 || id != APDS9960_DEVICE_ID_3)) {
     return false;
   }
 

--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -34,7 +34,13 @@
 #include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
 
-#define APDS9960_ADDRESS (0x39) /**< I2C Address */
+// Device I2C address
+#define APDS9960_ADDRESS (0x39)
+
+// Acceptable device IDs (inlude clones)
+#define APDS9960_DEVICE_ID_1 (0xAB)
+#define APDS9960_DEVICE_ID_2 (0xA8)
+#define APDS9960_DEVICE_ID_3 (0x9C)
 
 /** I2C Registers */
 enum {


### PR DESCRIPTION
There are some clones of the APDS9960 out in the wild which use a different device id. Per default the library fails during the device init if the id is not 0xAB like the original one. But some clones use 0xA8 as an id and some others 0x9C.

So improve handling of device ids and make those devices also work with this library.

Added new device ids to Adafruit_APDS9960.h as defines to make handling of these ids easier.

Changed if-statement in Adafruit_APDS9960.cpp -> Adafruit_APDS9960::begin(uint16_t iTimeMS, apds9960AGain_t aGain,                                 uint8_t addr, TwoWire *theWire) to check for those ids.

No known limitations. Should work on every platform.
