### PR TITLE
[FEATURE] Add support for APDS9960 clones

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -98,8 +98,9 @@ boolean Adafruit_APDS9960::begin(uint16_t iTimeMS, apds9960AGain_t aGain,
   }
 
   /* Make sure we're actually connected */
-  uint8_t x = read8(APDS9960_ID);
-  if (x != 0xAB) {
+  uint8_t id = read8(APDS9960_ID);
+  if (id != APDS9960_DEVICE_ID_1 && id != APDS9960_DEVICE_ID_2 &&
+      id != APDS9960_DEVICE_ID_3) {
     return false;
   }
 

--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -34,7 +34,17 @@
 #include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
 
-#define APDS9960_ADDRESS (0x39) /**< I2C Address */
+/**< I2C Address */
+#define APDS9960_ADDRESS (0x39)
+
+/** Original Chip */
+#define APDS9960_DEVICE_ID_1 (0xAB)
+
+/** Chinese clone */
+#define APDS9960_DEVICE_ID_2 (0xA8)
+
+/** Another Clone */
+#define APDS9960_DEVICE_ID_3 (0x9C)
 
 /** I2C Registers */
 enum {


### PR DESCRIPTION
Add support for more than one chip id and improve chip detection to initialize clones properly.

Adafruit_APDS9960.h:
Use defines to define more than one chip id and make handling of these easier.

Adafruit_APDS9960.cpp:
Improve chip detection part in Adafruit_APDS9960::begin() to handle more than one chip id and allow clones with different id than the genuine chip to be used without a failing initialization.

Should work with every platform and shouldn't break any existing code as the changes are minor ones.

Tested with a Chinese clone of the APDS9960 without problems.