### PR TITLE
added proximityDataReady function

### DIFF
--- a/Adafruit_APDS9960.cpp
+++ b/Adafruit_APDS9960.cpp
@@ -292,6 +292,15 @@ bool Adafruit_APDS9960::getProximityInterrupt() {
 };
 
 /*!
+ *  @brief  Returns status of proximity data
+ *  @return True if proximity data ready, False otherwise
+ */
+bool Adafruit_APDS9960::proximityDataReady() {
+  _status.set(this->read8(APDS9960_STATUS));
+  return _status.PVALID;
+}
+
+/*!
  *  @brief  Read proximity data
  *  @return Proximity
  */

--- a/Adafruit_APDS9960.h
+++ b/Adafruit_APDS9960.h
@@ -190,6 +190,7 @@ public:
   void setProxPulse(apds9960PPulseLen_t pLen, uint8_t pulses);
   void enableProximityInterrupt();
   void disableProximityInterrupt();
+  bool proximityDataReady();
   uint8_t readProximity();
   void setProximityInterruptThreshold(uint8_t low, uint8_t high,
                                       uint8_t persistence = 4);


### PR DESCRIPTION
It seems to me that this feature is missing; when you want to read proximity values continuously without asserting the interrupts. The data at PDATA is not valid between reading and the next update cycle, so reading PVALID should ensure that it is valid (according to the datasheet)

I have added a similar function to colorDataReady(), completing the interface.